### PR TITLE
v1.5.2

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,7 @@
+1.5.2 Added support for mixpulse and mixspin effects
+     Added -B option for macOS to fix audio in Bluetooth devices (see SBAGEN+.TXT for details)
+	 Deprecated AudioHardware.h and Carbon removed, using AudioObject API instead
+
 1.5.1 Isochronic added to -p drop/slide option
 
 1.5.0 Rebranded as SBaGen+ to indicate the fork from the original project   

--- a/USAGE.md
+++ b/USAGE.md
@@ -46,6 +46,11 @@ SBaGen+ uses a specific syntax to define tones:
 
   - Example: `300@10/20` - A 300Hz carrier pulsing at 10Hz at 20% amplitude
 
+- **Mixspin**: `mixspin:[width]+[frequency]/[amplitude]`
+
+  - Example: `mixspin:500+8.0/50` - A spinning effect with 500μs width, rotating at 8Hz with 50% intensity
+  - Note: Requires `mix/<amplitude>` to be specified in the same tone set
+
 - **Noise**: `[type]/[amplitude]`
   - Examples: `pink/40`, `white/30`, `brown/50`
 
@@ -58,6 +63,12 @@ pink/40 200+10/20 300@8/15
 ```
 
 This combines pink noise at 40% amplitude, a binaural beat with a 200Hz carrier and 10Hz beat at 20% amplitude, and an isochronic tone with a 300Hz carrier pulsing at 8Hz at 15% amplitude.
+
+```
+mix/80 mixspin:500+8.0/50
+```
+
+This creates a spinning effect on the audio input (mix) at 80% amplitude, with the spin rotating at 8Hz and an intensity of 50%.
 
 ## Command Line Basics
 
@@ -72,6 +83,9 @@ sbagen+ -i pink/40 300@6/20
 
 # Play a combination of brown noise and delta binaural beat for deep relaxation
 sbagen+ -i brown/50 100+3/25
+
+# Create a spinning effect on background music
+sbagen+ -m ambient-music.mp3 -i mix/80 mixspin:500+8.0/50
 
 # Play a sequence file
 sbagen+ my-sequence.sbg
@@ -211,5 +225,7 @@ Remember that brainwave entrainment is a tool to help you achieve certain mental
 ## Conclusion
 
 SBaGen+ is a powerful tool for exploring altered states of consciousness, enhancing meditation, improving focus, and aiding relaxation. This guide covers the basics to get you started, but there's much more to explore. As you become more familiar with the program, you can create increasingly sophisticated sequences tailored to your specific needs.
+
+For more technical details, see the [SBaGen+ Manual](docs/SBAGEN+.txt).
 
 Happy exploring!

--- a/USAGE.md
+++ b/USAGE.md
@@ -46,9 +46,14 @@ SBaGen+ uses a specific syntax to define tones:
 
   - Example: `300@10/20` - A 300Hz carrier pulsing at 10Hz at 20% amplitude
 
-- **Mixspin**: `mixspin:[width]+[frequency]/[amplitude]`
+- **Mixspin**: `mixspin:[width]+[frequency]/[intensity]`
 
   - Example: `mixspin:500+8.0/50` - A spinning effect with 500μs width, rotating at 8Hz with 50% intensity
+  - Note: Requires `mix/<amplitude>` to be specified in the same tone set
+
+- **Mixpulse**: `mixpulse:[pulse]/[intensity]`
+
+  - Example: `mixpulse:10/50` - A pulse effect with a rate of 10Hz and 50% intensity
   - Note: Requires `mix/<amplitude>` to be specified in the same tone set
 
 - **Noise**: `[type]/[amplitude]`
@@ -69,6 +74,12 @@ mix/80 mixspin:500+8.0/50
 ```
 
 This creates a spinning effect on the audio input (mix) at 80% amplitude, with the spin rotating at 8Hz and an intensity of 50%.
+
+```
+mix/80 mixpulse:10/50
+```
+
+This creates a pulse effect on the audio input (mix) at 80% amplitude, with the pulse rate of 10Hz and an intensity of 50%.
 
 ## Command Line Basics
 

--- a/docs/SBAGEN+.txt
+++ b/docs/SBAGEN+.txt
@@ -54,6 +54,7 @@ Contents of this document:
 2.6.1: More detailed notes on -p drop options
 2.6.2: Adjusting the length of a -p drop session
 2.7: The 'slide' sequences
+2.8: Buffer Size Configuration for Bluetooth Devices on macOS
 
 3: Writing sequence files
 3.1: The sequence-file format
@@ -907,6 +908,39 @@ audible on your headphones.  This is not a big problem, but if you
 want to try and get a little more out of your equipment, you could
 experiment with the -c amplitude-compensation option (see the section
 above).
+
+
+2.8: Buffer Size Configuration for Bluetooth Devices on macOS
+------------------------------------------------------------
+
+Usage:
+
+  -B size
+
+Example:
+
+  sbagen+ -B 2048 -i 200+10/1
+  
+  or in a sequence file:
+  
+  -B 2048 # optional comment
+
+On macOS, some users may experience audio distortion when using Bluetooth devices. This occurs because the default audio buffer size may not be suitable for the higher latency of these wireless devices.
+
+The -B option allows you to set a custom buffer size (in samples) for audio output on macOS. Larger values generally result in fewer distortions on Bluetooth devices, but may slightly increase latency.
+
+Important points about this option:
+
+1. The value must be a power of 2 (e.g., 1024, 2048, 4096, 8192)
+2. The value must be between 1024 and the 8192
+3. This option is only available for macOS users
+4. Recommended values for Bluetooth devices: 2048 or 4096
+
+If you're using Bluetooth headphones or wireless speakers and notice distortions, crackling, or interruptions in the audio, try adding the -B option with a larger value. For example:
+
+  sbagen+ -m river1.ogg -B 2048 -p drop 00ds+ mix/99
+
+This option can also be included directly in sequence files, as shown in the example above. This is useful for creating sequences optimized for Bluetooth devices without having to specify the option on the command line.
 
 
 3: Writing sequence files

--- a/docs/SBAGEN+.txt
+++ b/docs/SBAGEN+.txt
@@ -367,6 +367,14 @@ appears to rotate around your head. The width parameter (500μs in this example)
 controls how wide the rotation effect is, the frequency (8.0Hz) controls how
 fast it rotates, and the intensity (50%) controls the strength of the effect.
 
+You can also try the 'mixpulse' effect, which applies a pulse effect to the
+audio input instead of to pink noise:
+
+>> sbagen -m river1.ogg -i mix/80 mixpulse:10/50
+
+The mixpulse effect creates a rhythmic pulse effect where the sound intensity
+fluctuates at the given rate. The pulse rate is 10Hz and the intensity is 50%.
+
 If you're having trouble with your soundcard or CPU usage on a very
 old machine, use the -r or -b options to run at a lower output rate or
 bit-width.  For example:
@@ -1070,20 +1078,21 @@ adjusted in the source code -- search for N_CH).
 
 Here are the different types:
 
-  -                             # Channel not in use
-  pink/<amp>                    # Pink noise
-  white/<amp>                   # White noise
-  brown/<amp>                   # Brown noise
-  mix/<amp>                     # Soundtrack input mix
-  <carrier><sign><freq>/<amp>   # Binaural tones
-  <carrier>/<amp>		# Sine-wave (a binaural tone with 0Hz beat)
-  bell+<freq>/<amp>             # Bell sound
-  spin:<width>+<freq>/<amp>     # Spinning variable-delay pink noise
-  mixspin:<width>+<freq>/<amp>  # Spinning effect on mix input
-  <carrier>@<pulse>/<amp>       # Isochronic tones
+  -                                   # Channel not in use
+  pink/<amp>                          # Pink noise
+  white/<amp>                         # White noise
+  brown/<amp>                         # Brown noise
+  mix/<amp>                           # Soundtrack input mix
+  <carrier><sign><freq>/<amp>         # Binaural tones
+  <carrier>/<amp>		                  # Sine-wave (a binaural tone with 0Hz beat)
+  bell+<freq>/<amp>                   # Bell sound
+  spin:<width>+<freq>/<amp>           # Spinning variable-delay pink noise
+  mixspin:<width>+<freq>/<intensity>  # Spinning effect on mix input
+  mixpulse:<pulse>/<intensity>        # Pulse effect on mix input
+  <carrier>@<pulse>/<amp>             # Isochronic tones
   wave<num>:<carrier><sign><freq>/<amp>
-                                # Binaural tones using a user-defined 
-                                # waveform (*EXPERIMENTAL*, see later)
+                                      # Binaural tones using a user-defined 
+                                      # waveform (*EXPERIMENTAL*, see later)
 
 The amplitudes are expressed on a scale 0-100.  The total of all the
 amplitudes <amp> in a tone-set should not exceed 100, or else there
@@ -1141,13 +1150,19 @@ the beat frequency and the third is the amplitude, as above.
 The mixspin effect creates a spatial rotation effect on the audio input stream
 (specified with mix/<amp>). The <width> parameter controls the amplitude of 
 the rotation effect in microseconds (typically 100-500μs), <freq> determines 
-the rotation speed in Hz, and <amp> controls the intensity of the effect 
+the rotation speed in Hz, and <intensity> controls the intensity of the effect 
 (0-100%). For example, mixspin:500+8.0/50 creates a spinning effect with 
 500μs width, rotating at 8Hz with 50% intensity. This creates an immersive 
 spatial effect where the sound appears to rotate around the listener's head.
 The mixspin effect must be used in conjunction with a mix/<amp> specification
 in the same tone set, as it processes the audio input rather than generating
 its own tones. Higher intensity values create more pronounced rotation effects.
+
+The mixpulse effect creates a pulse effect on the audio input stream
+(specified with mix/<amp>). The <pulse> parameter controls the pulse rate in Hz,
+and <intensity> controls the intensity of the effect (0-100%). For example, mixpulse:10/50
+creates a pulse effect with a rate of 10Hz and 50% intensity. This creates a rhythmic
+pulse effect where the sound intensity fluctuates at the given rate.
 
 Binaural tones generated using wave<num> work just the same way as
 normal binaural tones.  See the section later on for details.

--- a/docs/SBAGEN+.txt
+++ b/docs/SBAGEN+.txt
@@ -194,6 +194,11 @@ While headphones are essential for binaural beats, isochronic tones can be
 effective with or without headphones, though headphones may still provide 
 a more immersive experience.
 
+The white noise generates a random signal with equal energy at all frequencies.
+It can be used for masking background sounds or as a meditation aid. The
+amplitude <amp> controls the volume level. For example, white/10 generates
+white noise at 10% amplitude.
+
 
 Some more theory -- the oscillations in the brain are split into four
 'bands' according to frequency:
@@ -351,6 +356,16 @@ While you're at it, try the alternate 'spin' effect.  Not everyone
 likes this, but in any case it's there if you want to use it:
 
 >> sbagen -i spin:300+4.2/80
+
+You can also try the 'mixspin' effect, which applies a spatial rotation to
+audio input instead of to pink noise:
+
+>> sbagen -m river1.ogg -i mix/80 mixspin:500+8.0/50
+
+The mixspin effect creates an immersive spatial experience where the sound
+appears to rotate around your head. The width parameter (500μs in this example)
+controls how wide the rotation effect is, the frequency (8.0Hz) controls how
+fast it rotates, and the intensity (50%) controls the strength of the effect.
 
 If you're having trouble with your soundcard or CPU usage on a very
 old machine, use the -r or -b options to run at a lower output rate or
@@ -1064,6 +1079,7 @@ Here are the different types:
   <carrier>/<amp>		# Sine-wave (a binaural tone with 0Hz beat)
   bell+<freq>/<amp>             # Bell sound
   spin:<width>+<freq>/<amp>     # Spinning variable-delay pink noise
+  mixspin:<width>+<freq>/<amp>  # Spinning effect on mix input
   <carrier>@<pulse>/<amp>       # Isochronic tones
   wave<num>:<carrier><sign><freq>/<amp>
                                 # Binaural tones using a user-defined 
@@ -1121,6 +1137,17 @@ this case, the first number is the width of the maximum delay from
 centre in microseconds.  Values from 100 to 500 seem good to me,
 although you might want to experiment with this.  The second number is
 the beat frequency and the third is the amplitude, as above.
+
+The mixspin effect creates a spatial rotation effect on the audio input stream
+(specified with mix/<amp>). The <width> parameter controls the amplitude of 
+the rotation effect in microseconds (typically 100-500μs), <freq> determines 
+the rotation speed in Hz, and <amp> controls the intensity of the effect 
+(0-100%). For example, mixspin:500+8.0/50 creates a spinning effect with 
+500μs width, rotating at 8Hz with 50% intensity. This creates an immersive 
+spatial effect where the sound appears to rotate around the listener's head.
+The mixspin effect must be used in conjunction with a mix/<amp> specification
+in the same tone set, as it processes the audio input rather than generating
+its own tones. Higher intensity values create more pronounced rotation effects.
 
 Binaural tones generated using wave<num> work just the same way as
 normal binaural tones.  See the section later on for details.

--- a/macos-build-sbagen+.sh
+++ b/macos-build-sbagen+.sh
@@ -20,7 +20,7 @@ OGG_LIB_PATH="libs/macos-universal-libogg.a"
 TREMOR_LIB_PATH="libs/macos-universal-libvorbisidec.a"
 
 # Define compilation flags
-CFLAGS="-DT_MACOSX -arch arm64 -arch x86_64 -mmacosx-version-min=11.0 -DNO_CARBON -Wno-deprecated-declarations -I."
+CFLAGS="-DT_MACOSX -arch arm64 -arch x86_64 -mmacosx-version-min=11.0 -I."
 LIBS="-framework CoreAudio"
 
 # Check for MP3 support

--- a/sbagen+.c
+++ b/sbagen+.c
@@ -227,6 +227,7 @@ extern int out_rate, out_rate_def;
 void create_drop(int ac, char **av);
 void create_slide(int ac, char **av);
 void validateTotalAmplitude(Voice *voices, int numChannels, const char *line, int lineNum);
+void printSequenceDuration();
 
 #define ALLOC_ARR(cnt, type) ((type*)Alloc((cnt) * sizeof(type)))
 #define uint unsigned int
@@ -1445,8 +1446,7 @@ loop() {
     byte_count= out_bps * (S64)(duration * 0.001 * out_rate /
                 (fast ? fast_mult : 1));
     if (!opt_Q) {
-      fprintf(stderr, "*** Sequence duration: %02d:%02d:%02d (hh:mm:ss) ***\n", 
-              duration/3600000, (duration/60000)%60, (duration/1000)%60);
+      printSequenceDuration();
     }
   }
 
@@ -2820,6 +2820,11 @@ correctPeriods() {
       while (per->prv->tim < per->tim) per= per->nxt;
 
     pp= per;
+
+    if(!opt_Q) {
+      printSequenceDuration();
+    }
+
     do {
       dispCurrPer(stdout);
       per= per->nxt;
@@ -3565,6 +3570,12 @@ void validateTotalAmplitude(Voice *voices, int numChannels, const char *line, in
     error("Total amplitude exceeds 100%% (%.2f%%) at line %d:\n  %s\nPlease reduce amplitudes to prevent audio distortion.", 
           totalAmplitude, lineNum, line);
   }
+}
+
+void printSequenceDuration() {
+  int duration = t_per0(fast_tim0, fast_tim1);
+  fprintf(stdout, "\n*** Sequence duration: %02d:%02d:%02d (hh:mm:ss) ***\n\n", 
+          duration/3600000, (duration/60000)%60, (duration/1000)%60);
 }
 
 // END //

--- a/sbagen+.c
+++ b/sbagen+.c
@@ -2340,7 +2340,7 @@ setup_device(void) {
 	    "default output uses another format");
 
     // Set buffer size
-    bufferByteCount = buffer_size * sizeof(float);
+    bufferByteCount = (float) buffer_size / 2 * sizeof(float);
     propertySize = sizeof(bufferByteCount);
     propertyAddress.mSelector = kAudioDevicePropertyBufferSize;
     propertyAddress.mScope = kAudioObjectPropertyScopeGlobal;

--- a/sbagen+.c
+++ b/sbagen+.c
@@ -2,7 +2,7 @@
 //	SBaGen+ - Sequenced Brainwave Generator
 //
 //	Original version (c) 1999-2011 Jim Peters <jim@uazu.net>
-//	Current fork maintained by Ruan <https://ruan.sh/>
+//	This fork maintained by Ruan <https://ruan.sh/>
 //
 //	For latest version see http://sbagen.sf.net/ or
 //	http://uazu.net/sbagen/. Released under the GNU GPL version 2.
@@ -30,7 +30,7 @@
 //	FINK project's patches to ESounD, by Shawn Hsiao and Masanori
 //	Sekino.  See: http://fink.sf.net
 
-#define VERSION "1.5.0"
+#define VERSION "1.5.2"
 
 // This should be built with one of the following target macros
 // defined, which selects options for that platform, or else with some
@@ -255,12 +255,12 @@ void
 help() {
    printf("SBaGen+ - Sequenced Brainwave Generator, version " VERSION
      NL "Original version (c) 1999-2011 Jim Peters, http://uazu.net/"
-     NL "Current fork maintained by Ruan, https://ruan.sh/"
+     NL "This fork maintained by Ruan, https://ruan.sh/"
 	  NL "Released under the GNU GPL v2. See file COPYING."
 	  NL 
-	  NL "Usage: sbagen [options] seq-file ..."
-	  NL "       sbagen [options] -i tone-specs ..."
-	  NL "       sbagen [options] -p pre-programmed-sequence-specs ..."
+	  NL "Usage: sbagen+ [options] seq-file ..."
+	  NL "       sbagen+ [options] -i tone-specs ..."
+	  NL "       sbagen+ [options] -p pre-programmed-sequence-specs ..."
 	  NL
 	  NL "Options:  -h        Display this help-text"
 	  NL "          -Q        Quiet - don't display running status"
@@ -321,30 +321,24 @@ void
 usage() {
   error("SBaGen+ - Sequenced Brainwave Generator, version " VERSION 
 	NL "Original version (c) 1999-2011 Jim Peters, http://uazu.net/"
-	NL "Current fork maintained by Ruan, https://ruan.sh/"
+	NL "This fork maintained by Ruan, https://ruan.sh/"
 	NL "Released under the GNU GPL v2. See file COPYING."
 	NL 
-	NL "Usage: sbagen [options] seq-file ..."
-	NL "       sbagen [options] -i tone-specs ..."
-	NL "       sbagen [options] -p pre-programmed-sequence-specs ..."
+	NL "Usage: sbagen+ [options] seq-file ..."
+	NL "       sbagen+ [options] -i tone-specs ..."
+	NL "       sbagen+ [options] -p pre-programmed-sequence-specs ..."
 	NL
-	NL "For full usage help, type 'sbagen -h'."
 	NL "SBaGen+ is a fork of the original SBaGen with added features."
+	NL "For full usage help, type 'sbagen+ -h'."
 #ifdef EXIT_KEY
 	NL
 	NL "Windows users please note that this utility is designed to be run as the"
 	NL "associated application for SBG files.  This should have been set up for you by"
 	NL "the installer.  You can run all the SBG files directly from the desktop by"
 	NL "double-clicking on them, and edit them using NotePad from the right-click menu."
-	NL "Alternatively, SBaGen may be run from the MS-DOS prompt (CMD on WinXP), or from"
-	NL "BAT files.  SBaGen is powerful software -- it is worth the effort of figuring"
-	NL "all this out.  See SBAGEN.TXT for the full documentation."
-	NL
-	NL "Editing the SBG files gives you access to the full tweakable power of SBaGen, "
-	NL "but if you want a simple GUI interface to the most basic features, you could "
-	NL "look at a user-contributed tool called SBaGUI:"
-	NL
-	NL "  http://sbagen.opensrc.org/wiki.php?page=SBaGUI"
+	NL "Alternatively, SBaGen+ may be run from the command line, or from"
+	NL "BAT/PS1 files.  SBaGen+ is powerful software -- it is worth the effort of figuring"
+	NL "all this out.  See SBAGEN+.TXT for the full documentation."
 #endif
 	NL);
 }
@@ -919,7 +913,7 @@ scanOptions(int *acp, char ***avp) {
 		error("Expecting integer after -R");
 	     break;
 	  default:
-	     error("Option -%c not known; run 'sbagen -h' for help", opt);
+	     error("Option -%c not known; run 'sbagen+ -h' for help", opt);
 	 }
       }
    }


### PR DESCRIPTION
- Added support for mixpulse and mixspin effects
- Added -B option for macOS to fix audio in Bluetooth devices (see SBAGEN+.TXT for details)
- Deprecated AudioHardware.h and Carbon removed, using AudioObject API instead